### PR TITLE
Disable logs for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.node-version == env.node_version }} # only upload coverage from node 14
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           npm run coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,9 +1109,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
+      "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg==",
       "dev": true
     },
     "@types/parse-json": {
@@ -2714,9 +2714,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+      "integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.8",
@@ -5364,9 +5364,9 @@
       "dev": true
     },
     "pino": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.12.0.tgz",
-      "integrity": "sha512-5NGopOcUusGuklGHVVv9az0Hv/Dj3urHhD3G+zhl5pBGIRYAeGCi/Ej6YCl16Q2ko28cmYiJz+/qRoJiwy62Rw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.0.tgz",
+      "integrity": "sha512-mRXSTfa34tbfrWqCIp1sUpZLqBhcoaGapoyxfEwaWwJGMpLijlRdDKIQUyvq4M3DUfFH5vEglwSw8POZYwbThA==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2960,9 +2960,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "author": "Brigham Young University - Office of Information Technology",
   "license": "Apache-2.0",
   "dependencies": {
-    "pino": "^6.12.0"
+    "pino": "^6.13.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "@types/node": "^16.3.3",
+    "@types/node": "^16.4.0",
     "@types/pino": "^6.3.9",
     "jest": "^27.0.6",
     "lint-staged": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Default configuration for pino logger",
   "contributors": [
     "Scott Hutchings <scott_hutchings@byu.edu>"

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,7 +3,16 @@ import Pino, { LoggerOptions, Logger } from 'pino'
 export default function DefaultLogger (options?: LoggerOptions): Logger {
   const isDeployed = process.env.NODE_ENV === 'production'
   return Pino({
-    level: isDeployed ? 'info' : 'debug',
+    level: (() => {
+      switch (process.env.NODE_ENV) {
+        case 'production':
+          return 'info'
+        case 'test':
+          return 'silent'
+        default:
+          return 'debug'
+      }
+    })(),
     messageKey: 'message',
     formatters: {
       level: level => ({ level }) // display the level not the number value of the level

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,6 @@
 import Pino, { LoggerOptions, Logger } from 'pino'
 
 export default function DefaultLogger (options?: LoggerOptions): Logger {
-  const isDeployed = process.env.NODE_ENV === 'production'
   return Pino({
     level: (() => {
       switch (process.env.NODE_ENV) {
@@ -23,7 +22,7 @@ export default function DefaultLogger (options?: LoggerOptions): Logger {
       paths: ['req.headers.authorization', 'req.headers.assertion', 'req.headers["x-jwt-assertion"]', 'req.headers["x-jwt-assertion-original"]'],
       censor: '***'
     },
-    prettyPrint: isDeployed ? false : {
+    prettyPrint: process.env.NODE_ENV === 'production' ? false : {
       // if in local environment use pretty print logs
       translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' // show timestamp instead of epoch time
     },

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -119,3 +119,28 @@ describe('In production env', () => {
     expect(jsonLogEntry.time).toEqual(jan1st.getTime())
   })
 })
+
+describe('In test env', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+  })
+
+  test('default logger should default to silent level', () => {
+    process.stdout.write = captureStdoutLogs()
+
+    const logger = DefaultLogger()
+    logger.debug('debug does not work')
+
+    expect(logger.level).toEqual('silent')
+    expect(logged).toEqual('') // no logs should have happened
+  })
+
+  test('default logger should not display logs', () => {
+    process.stdout.write = captureStdoutLogs()
+
+    const logger = DefaultLogger()
+    logger.info('info works')
+
+    expect(logged).toEqual('')
+  })
+})


### PR DESCRIPTION
Jest will set `NODE_ENV=test` [when it's running](https://jestjs.io/docs/environment-variables). Disabling logs during testing will clean up the test output and not dirty it with unnecessary log data. If someone needs to see what is being logged, they can use their IDE's debug tool.
