### PR TITLE
Add pino types as peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
+    "@types/pino": "^6.3.10",
     "pino-pretty": "^5.1.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Default configuration for pino logger",
   "contributors": [
     "Scott Hutchings <scott_hutchings@byu.edu>"


### PR DESCRIPTION
Other TypeScript projects may need `@types/pino` in their project to correctly resolve the type of the exported logger. I _think_ using peer dependencies is a way to show that, but if there is a deeper problem here or this isn't the right way to go about this, let me know.