### PR TITLE
Update pino/pino-pretty, use pino-pretty as a transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
   "license": "Apache-2.0",
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "pino": "^6.13.3"
+    "pino": "^7.5.1"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.9",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.1",
-    "@types/pino": "^6.3.12",
     "jest": "^27.2.0",
     "lint-staged": "^12.0.2",
-    "pino-pretty": "^6.0.0",
+    "pino-pretty": "^7.3.0",
     "rimraf": "^3.0.2",
     "snazzy": "^9.0.0",
     "ts-jest": "^27.0.5",
@@ -39,7 +38,7 @@
     "typescript": "^4.4.3"
   },
   "optionalDependencies": {
-    "pino-pretty": "<6"
+    "pino-pretty": "^7.3.0"
   },
   "engines": {
     "node": ">=12"

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,7 +17,13 @@ export default function DefaultLogger (options?: Pino.LoggerOptions): Pino.Logge
     },
     // if in local environment use pretty print logs
     ...process.env.NODE_ENV !== 'production' && isInstalled('pino-pretty') && {
-      prettyPrint: { translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' } // show timestamp instead of epoch time
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'', // show timestamp instead of epoch time
+          messageKey: 'message'
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Pino deprecated the `prettyPrint` option, and will remove it in the next major version. This is now the preferred way to do things.

Note that we had to change the range on `pino-pretty`, because this new functionality was introduced in v7. So, it's technically breaking in that we require any users to update `pino-pretty` if they want the existing `prettyPrint` behavior.

I see we're still pre-v1.0. Shall I call this 0.4.0?