### PR TITLE
fix: error with pretty-print and jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Default configuration for pino logger",
   "contributors": [
     {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,11 +15,13 @@ export function ByuLogger (options?: LoggerOptions): Logger {
       paths: ['req.headers.authorization', 'req.headers.assertion', 'req.headers["x-jwt-assertion"]', 'req.headers["x-jwt-assertion-original"]'],
       censor: '***'
     },
-    // if in local environment try to pretty print logs
-    ...!isProduction() && isInstalled('pino-pretty') && {
+    // if in local environment and not running tests try to pretty print logs
+    // jest and pretty-print don't get along (causes open handles and sometimes doesn't close),
+    // so we'll default to not include pretty-print if running tests
+    ...!isProduction() && process.env.NODE_ENV !== 'test' && isInstalled('pino-pretty') && {
       transport: {
         target: 'pino-pretty',
-        options: { translateTime: 'UTC:yyyy-mm-dd HH:MM:ss.l' }
+        options: { translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' }
       }
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,7 +19,7 @@ export function ByuLogger (options?: LoggerOptions): Logger {
     ...!isProduction() && isInstalled('pino-pretty') && {
       transport: {
         target: 'pino-pretty',
-        options: { translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' }
+        options: { translateTime: 'UTC:yyyy-mm-dd HH:MM:ss.l' }
       }
     }
   }


### PR DESCRIPTION
jest detected hanging functions and I believe it's pino-pretty and jest don't work well together.

https://github.com/pinojs/pino-pretty?tab=readme-ov-file#usage-with-jest

I've tried adding the `sync` property and that doesn't seem to help. So instead we can just default to not include pretty print if we're running tests. I suspect that the real issue is that jest with pretty print seem to introduce a race condition that doesn't always finish before jest finishes.