### PR TITLE
chore: remove unnecessary types for pino

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@tsconfig/node12": "^1.0.11",
     "@types/jest": "^29.5.0",
     "@types/node": "^16.9.1",
-    "@types/pino": "^7.0.5",
     "jest": "^29.5.0",
     "lint-staged": "^12.0.2",
     "pino-pretty": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Default configuration for pino logger",
   "contributors": [
     {


### PR DESCRIPTION
pino ships with its own type declaration files so we don't need to install them from the @types/pino package