### PR TITLE
chore: support esm syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Default configuration for pino logger",
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@byu-oit/logger",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Default configuration for pino logger",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "contributors": [
     {
@@ -35,14 +35,14 @@
     "dist"
   ],
   "scripts": {
-    "build": "rimraf dist && concurrently \"npm:build:*\" -c cyanBright",
+    "build": "npm run clean && concurrently \"npm:build:*\" -c cyanBright",
     "build:cjs": "tsc -p tsconfig.cjs.json && echo-cli \"{\\\"type\\\": \\\"commonjs\\\"}\" > dist/cjs/package.json",
     "build:esm": "tsc -p tsconfig.json && echo-cli \"{\\\"type\\\": \\\"module\\\"}\" > dist/esm/package.json",
     "clean": "rimraf dist",
-    "coverage": "c8 ava",
+    "coverage": "c8 npm run test",
     "lint": "npx ts-standard | snazzy",
     "lint:fix": "npx ts-standard --fix | snazzy",
-    "test": "ava",
+    "test": "node --import tsimp --test test/*.spec.ts",
     "prepublishOnly": "npm run build"
   },
   "author": "Brigham Young University - Office of Information Technology",
@@ -60,32 +60,20 @@
     "pino-http": "^10.2.0"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
-    "@types/node": "^18.19.42",
-    "@types/sinon": "^17.0.3",
-    "ava": "^6.1.3",
+    "@tsconfig/node-lts": "^20.1.3",
+    "@tsconfig/node20": "^20.1.4",
+    "@types/node": "^22.7.5",
     "c8": "^10.1.2",
     "concurrently": "^8.2.2",
     "echo-cli": "^2.0.0",
     "pino-pretty": "^11.2.2",
     "rimraf": "^6.0.1",
-    "sinon": "^18.0.0",
     "snazzy": "^9.0.0",
+    "ts-standard": "^12.0.2",
     "tsimp": "^2.0.11",
     "typescript": "^5.5.4"
   },
   "optionalDependencies": {
     "pino-pretty": ">=7"
-  },
-  "lint-staged": {
-    "*.ts": "npm run lint:fix"
-  },
-  "ava": {
-    "extensions": {
-      "ts": "module"
-    },
-    "nodeArguments": [
-      "--import=tsimp"
-    ]
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import deepmerge from 'deepmerge'
 import { Logger, LoggerOptions, pino } from 'pino'
-import { getLevel, isInstalled, isProduction } from './util.js'
+import { getLevel, isProduction } from './util.js'
 
 export function ByuLogger (options?: LoggerOptions): Logger {
   const defaultOptions: LoggerOptions = {
@@ -18,10 +18,10 @@ export function ByuLogger (options?: LoggerOptions): Logger {
     // if in local environment and not running tests try to pretty print logs
     // jest and pretty-print don't get along (causes open handles and sometimes doesn't close),
     // so we'll default to not include pretty-print if running tests
-    ...!isProduction() && process.env.NODE_ENV !== 'test' && isInstalled('pino-pretty') && {
+    ...!isProduction() && process.env.NODE_ENV !== 'test' && {
       transport: {
         target: 'pino-pretty',
-        options: { translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' }
+        options: { sync: true, translateTime: 'UTC:yyyy-mm-dd\'T\'HH:MM:ss.l\'Z\'' }
       }
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,4 @@
-import { createRequire } from 'node:module'
 import Pino from 'pino'
-
-// @ts-ignore
-const nodeRequire = createRequire(import.meta.url)
 
 const ENV_LEVELS: Record<string, Pino.LevelWithSilent> = {
   production: 'info',
@@ -16,17 +12,6 @@ export function getLevel (level: string = 'default'): Pino.LevelWithSilent {
 
 export function isProduction (): boolean {
   return process.env.NODE_ENV === 'production'
-}
-
-export function isInstalled (name: string): boolean {
-  try {
-    return nodeRequire(name) !== null
-  } catch (e) {
-    if (isRecord(e) && hasProperty(e, 'code') && e.code === 'MODULE_NOT_FOUND') {
-      return false
-    }
-    throw e
-  }
 }
 
 export function isRecord (value: unknown): value is Record<string, unknown> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module'
 import Pino from 'pino'
+
+// @ts-ignore
+const nodeRequire = createRequire(import.meta.url)
 
 const ENV_LEVELS: Record<string, Pino.LevelWithSilent> = {
   production: 'info',
@@ -16,7 +20,7 @@ export function isProduction (): boolean {
 
 export function isInstalled (name: string): boolean {
   try {
-    return require(name) != null
+    return nodeRequire(name) !== null
   } catch (e) {
     if (isRecord(e) && hasProperty(e, 'code') && e.code === 'MODULE_NOT_FOUND') {
       return false

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,12 +1,17 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
+    "target": "es2022",
     "declaration": true,
     "declarationMap": true,
     "module": "CommonJS",
     "moduleResolution": "node",
     "declarationDir": "dist/cjs",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "esModuleInterop": true,
+    "importHelpers": true,
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,12 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "node16",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16",
     "declaration": true,
     "declarationDir": "dist/esm",
     "outDir": "dist/esm"


### PR DESCRIPTION
We don't need the isInstalled function because pino already checks for the transport package and will fail if it doesn't exist (i.e. it's a redundant blocker). Given this I also added the sync: true flag which is the [recommended config](https://github.com/pinojs/pino-pretty?tab=readme-ov-file#usage-with-jest) for jest due the async blocker.

Additionally refactoring tsconfigs for cjs/esm interop. Maybe one day we'll not need to care about this. I pray this day comes soon.

Bumped node support to 20+ (if you're on 18, 20 should be an easy move). This subsequently bumps the version to 2.